### PR TITLE
fix pip package name

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -108,7 +108,7 @@ The DroneKit library is available on the public pypi repository. You can use the
 
 ::
 
-    pip install droneapi-python
+    pip install droneapi
 
 
 Setting up DroneKit on a companion computer


### PR DESCRIPTION
fix install command on docs, ```droneapi-python``` is not the correct pip package name