### PR TITLE
Minor fixes to remove all build errors and fix linking/highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 droneapi.egg-info
 dist
 build
+*~
 

--- a/docs/automodule.rst
+++ b/docs/automodule.rst
@@ -1,5 +1,6 @@
 DroneKit Python Doc
-============================================
+===================
+
 
 .. automodule:: droneapi.lib
    :members:

--- a/docs/example_1.rst
+++ b/docs/example_1.rst
@@ -1,12 +1,12 @@
-First Demo: Simple Go to
-===============
+First Demo: Simple Go To
+========================
 
 This little demonstration just tells the vehicle to fly to a couple of different locations in the world.  You can edit the code to pick a latitude and longitude close to your position.
 
 Running the example
----------------
+-------------------
 
-Once Mavproxy is running and the API is loaded, you can run this small example by typing "api start simple_goto.py."
+Once Mavproxy is running and the API is loaded, you can run this small example by typing: ``api start simple_goto.py``
 
 It will tell your vehicle to start flying to a particular latitude and longitude stored in the file (though for safety the take-off command is not included - you must manually tell vehicle to fly).  On the mavproxy console you should see:
 
@@ -20,7 +20,7 @@ It will tell your vehicle to start flying to a particular latitude and longitude
 
 
 How does it work?
----------------
+-----------------
 
 The key code in this demo is the following:
 
@@ -32,7 +32,7 @@ The key code in this demo is the following:
 	commands.goto(origin)
 	vehicle.flush()
 
-It tells the vehicle to fly to a specified lat/long and hover at that location (30 meters in the air).  is_relative=True is the default and is recommended - it means that the altitude (30 meters) is *relative* to the vehicle home location.  If you had set is_relative to false, it would have told the vehicle to fly to a specified mean-sea-level which is probably not what you want unless you are next to an ocean.
+It tells the vehicle to fly to a specified lat/long and hover at that location (30 meters in the air).  ``is_relative=True`` is the default and is recommended - it means that the altitude (30 meters) is *relative* to the vehicle home location.  If you had set ``is_relative`` to ``false``, it would have told the vehicle to fly to a specified mean-sea-level which is probably not what you want unless you are next to an ocean.
 
 
 Building on the basic vehicle control you just learned, we now show how to write a small web application that allows you to command a drone to fly to a particular location.

--- a/docs/example_2.rst
+++ b/docs/example_2.rst
@@ -1,11 +1,13 @@
 Second Demo: Drone Delivery
-===============
+===========================
 
-This demonstration is a bit more extensive.  It is a [CherryPy](http://www.cherrypy.org) based web application that mapbox map to let you view the current vehicle position and send the vehicle commands to fly to a particular latitude longitude.
+This demonstration is a bit more extensive.  It is a `CherryPy <http://www.cherrypy.org>`_ based web application that displays a mapbox map to let you view the current vehicle position and send the vehicle commands to fly to a particular latitude and longitude.
 
-New functionality demonstrated here includes:
+New functionality demonstrated by this example includes:
+
 * Using attribute observers to be notified of vehicle state changes.
-* Starting cherrypy from a DroneKit application
+* Starting *CherryPy* from a DroneKit application.
+
 
 Starting the demo
 ------------------
@@ -32,7 +34,7 @@ The demonstration is started similar to the previous tutorials.  You should see 
 	GPS lock at 0 meters
 
 Screenshots
-------------------
+-----------
 
 You should be able to reach your new webserver at http://localhost:8080. It will look like the following:
 
@@ -42,11 +44,12 @@ You should be able to reach your new webserver at http://localhost:8080. It will
 
 .. image:: https://github.com/diydrones/droneapi-python/raw/master/example/documentation/drone-delivery-command.png
 
+
 Looking at the code
-------------------
+-------------------
 
 Using attribute observers
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 All attributes in DroneKit can have observers - this is the primary mechanism you should use to be notified of changes in vehicle state.  For instance, `drone_delivery.py <https://github.com/diydrones/droneapi-python/blob/master/example/drone_delivery/drone_delivery.py>`_ calls:
 
@@ -65,13 +68,13 @@ All attributes in DroneKit can have observers - this is the primary mechanism yo
         self.current_location = location
 
 
-This results in DroneKit calling our location_callback method any time the location attribute gets changed.
+This results in DroneKit calling our ``location_callback`` method any time the location attribute gets changed.
 
-Starting cherrypy from a DroneKit application
-~~~~~~~~~~~~~~~~~~
+Starting CherryPy from a DroneKit application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We start running a web server by calling cherrypy.engine.start().
+We start running a web server by calling ``cherrypy.engine.start()``.
 
-CherryPy is a very small and simple webserver.  It is probably best to refer to their eight line `tutorial <http://www.cherrypy.org/>`_ for more information.
+*CherryPy* is a very small and simple webserver.  It is probably best to refer to their eight line `tutorial <http://www.cherrypy.org/>`_ for more information.
 
 Next we'll look at the basics of using the webservice and the local vehicle API to 'replay' a flight which has been uploaded to `Droneshare <http://droneshare.com>`_.

--- a/docs/example_3.rst
+++ b/docs/example_3.rst
@@ -1,18 +1,19 @@
 Third Demo: Flight Replay
-===============
+=========================
 
 This is an interesting demo that uses our web API to query raw flight data from a particular flight.
 
-Starting the demo
-------------------
 
-In this case, we pick some public flight from Droneshare:
+Starting the demo
+-----------------
+
+In this case, we pick some public flight from `Droneshare <http://www.droneshare.com/>`_:
 
 .. image:: https://github.com/diydrones/droneapi-python/raw/master/example/documentation/flight_replay_example.png
 
 You'll notice that the mission number for this flight is 101.
 
-Now we'll launch [flight_replay.py](../flight_replay/flight_replay.py) and ask it to try and 'replay' mission 101.  It will ask the web server for representative points from the flight, parse the JSON response and use that data to generate 100 waypoints we would like our vehicle to hit.  For safety rather than using the altitude from the original flight we instead ask our vehicle to fly at a height of 30 meters.
+Now we'll launch **flight_replay.py** (/example/flight_replay/flight_replay.py) and ask it to try and 'replay' mission 101.  It will ask the web server for representative points from the flight, parse the JSON response and use that data to generate 100 waypoints we would like our vehicle to hit.  For safety rather than using the altitude from the original flight we instead ask our vehicle to fly at a height of 30 meters.
 
 One possible use of some variant of this tool to replay your old flights at your regular test field.
 
@@ -34,8 +35,9 @@ One possible use of some variant of this tool to replay your old flights at your
 	Got MAVLink msg: MISSION_ACK {target_system : 255, target_component : 0, type : 0}
 	APM: flight plan received
 
+
 How it works
-------------------
+------------
 
 Getting the points
 ~~~~~~~~~~~~~~~~~~
@@ -53,11 +55,12 @@ The following simple function asks for the droneshare flight data:
 
 Some comments:
 
-* max_freq is used to throttle the messages found in the raw flight data to a lower message rate
-* _decode_dict is a utility function found on stack overflow which extracts usable strings from unicode encoded JSON (see flight_replay.py for its implementation).
+* ``max_freq`` is used to throttle the messages found in the raw flight data to a lower message rate
+* ``_decode_dict`` is a utility function found on stack overflow which extracts usable strings from unicode encoded JSON (see `flight_replay.py <https://github.com/hamishwillee/dronekit-python/blob/master/example/flight_replay/flight_replay.py>`_ for its implementation).
+
 
 Setting the new waypoints
-------------------
+-------------------------
 
 We generate up to 100 wpts for the vehicle with the following code:
 
@@ -83,4 +86,5 @@ We generate up to 100 wpts for the vehicle with the following code:
         cmds.add(cmd)
     v.flush()
 
-Next we'll work with existing Linux services (gpsd) to add a new drone based feature called Follow Me.
+
+Next we'll work with existing Linux services (gpsd) to add a new drone based feature called :doc:`Follow Me <example_4>`.

--- a/docs/example_4.rst
+++ b/docs/example_4.rst
@@ -1,5 +1,5 @@
 Fourth Demo: Follow Me
-===============
+======================
 
 This is a significantly more complex example – showing closed-loop control of the vehicle. It will use a USB GPS attached to your laptop to have the vehicle follow you as you walk around a field.
 
@@ -15,7 +15,7 @@ Before running this demo you'll need to make sure your computer has the gpsd ser
 
     apt-get install gpsd gpsd-clients
 
-You can then plug in a USB GPS and run the "xgps" client to confirm that it is working. If you do not have a USB GPS you can use simulated data by running droneapi-python/example/run-fake-gps.sh.
+You can then plug in a USB GPS and run the "xgps" client to confirm that it is working. If you do not have a USB GPS you can use simulated data by running *droneapi-python/example/run-fake-gps.sh*.
 
 Once your GPS is plugged in you can start follow-me by running the following command inside of MAVProxy:
 
@@ -33,4 +33,5 @@ These debugging messages will appear every two seconds - when a new target posit
 
 The source code for this example is a good starting point for your own application, from here you can use all python language features and libraries (OpenCV, classes, lots of packages etc...)
 
-Next, take a look at the full DroneKit Python doc for more information.
+Next, take a look at the full :doc:`DroneKit Python doc <automodule>` for more information.
+

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -115,7 +115,7 @@ The DroneKit library is available on the public pypi repository. You can use the
 
 ::
 
-    pip install droneapi-python
+    pip install droneapi
 
 
 Setting up DroneKit on a companion computer

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,22 +1,25 @@
 Getting Started
-==================
+===============
 
 The best way to prototype apps for drones is to use a simulated vehicle. APM provides a Software-In-The-Loop (SITL) environment, which simulates a copter or plane, in Linux.
 
 If you want to test your app in real life, you should also grab a ready to fly copter from the  `3D Robotics Store <http://store.3drobotics.com>`_.
 
+
 Set up a simulated vehicle
-------------------
+--------------------------
+
 
 Dependencies
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 If you are using Mac OSX or Windows, you need to set up a virtual Linux machine to run SITL. 
 
 A popular virtual machine manager for running SITL is `Virtual Box <https://www.virtualbox.org/>`_. A virtual machine running Ubuntu Linux 13.04 or later works great.
 
+
 Set up SITL on Linux
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Please see `instructions here <http://dev.ardupilot.com/wiki/setting-up-sitl-on-linux/>`_ to set up SITL on Ubuntu.
 
@@ -32,13 +35,14 @@ Once you have the simulated vehicle running, enter the following commands. (You 
 
 
 Installing DroneKit
-------------------
+-------------------
 
 If you are using a virtual vehicle to prototype, it is recommended that you install DroneKit on that virtual environment where you are running SITL.
 
 If you are planning to run DroneKit on an onboard computer, make sure that the onboard computer run a variant of Linux that support Python and can install Python packages from the internet.
 
-Linux Dependencies
+
+Linux dependencies
 ~~~~~~~~~~~~~~~~~~
 
 If you are running Ubuntu or Debian Linux you can get all the DroneKit dependencies by running:
@@ -47,8 +51,9 @@ If you are running Ubuntu or Debian Linux you can get all the DroneKit dependenc
 
     sudo apt-get install pip python-numpy python-opencv python-serial python-pyparsing python-wxgtk2.8
 
-OSX Dependencies
-~~~~~~~~~~~~~~~~~~
+
+OSX dependencies
+~~~~~~~~~~~~~~~~
 
 If you're on Mac OSX, you can use `Homebrew <http://brew.sh/>`_ to install WXMac.
 
@@ -68,8 +73,9 @@ On OSX you need to uninstall python-dateutil since osx comes bundled with a vers
 
     pip uninstall python-dateutil
 
-Windows Dependencies
-~~~~~~~~~~~~~~~~~~
+
+Windows dependencies
+~~~~~~~~~~~~~~~~~~~~
 
 The windows installation is a little more involved, but not too hard.
 
@@ -91,7 +97,7 @@ Open the folder where you installed WinPython, run "*WinPython Control Panel*" a
 	pip install droneapi
 
 Install MAVProxy
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 When developing new DroneKit Python code the easiest approach is to run it inside of MAVProxy, a lightweight CLI tool to send MAVLink messages. Learn more about MAVProxy `here <http://tridge.github.io/MAVProxy/>`_. 
 
@@ -101,8 +107,9 @@ Install MAVProxy with the following command:
 
     sudo pip install MAVProxy
 
+
 Set up DroneKit
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 The DroneKit library is available on the public pypi repository. You can use the PyPi tool to install.
 
@@ -112,7 +119,7 @@ The DroneKit library is available on the public pypi repository. You can use the
 
 
 Setting up DroneKit on a companion computer
-------------------
+-------------------------------------------
 
 A companion computer can augment the processing power and flexibility of the autopilot, allowing you to perform tasks like computer vision and directly control the drone through a low latency link with the flight controller.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,10 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to DroneKit Python's documentation!
-====================================
+Welcome to DroneKit-Python's documentation!
+===========================================
 
-DroneKit Python provides interfaces for creating  applications that run on an onboard Linux computer communicating directly to the autopilot of 3DR-powered vehicles or applications that run on a personal computer communicating with vehicles over a wireless connection.
+DroneKit-Python provides interfaces for creating  applications that run on an onboard Linux computer communicating directly to the autopilot of 3DR-powered vehicles or applications that run on a personal computer communicating with vehicles over a wireless connection.
 
 DroneKit is compatible with all vehicles using the `MAVLink protocol <http://qgroundcontrol.org/mavlink/start>`_. This includes most vehicles made by 3DR and other members of the `DroneCode foundation <https://www.dronecode.org/about/project-members>`_.
 


### PR DESCRIPTION
This fixes all the build warnings (mostly resulting from heading underlines being too short) and otherwise fixes minor issues with text described in https://github.com/diydrones/dronekit-python/issues/33