### PR TITLE
Rename API Reference doc

### DIFF
--- a/docs/automodule.rst
+++ b/docs/automodule.rst
@@ -1,5 +1,5 @@
-DroneKit Python Doc
-===================
+DroneKit-Python API Reference
+=============================
 
 
 .. automodule:: droneapi.lib

--- a/docs/example_4.rst
+++ b/docs/example_4.rst
@@ -33,5 +33,5 @@ These debugging messages will appear every two seconds - when a new target posit
 
 The source code for this example is a good starting point for your own application, from here you can use all python language features and libraries (OpenCV, classes, lots of packages etc...)
 
-Next, take a look at the full :doc:`DroneKit Python doc <automodule>` for more information.
+Next, take a look at the full :doc:`DroneKit-Python API Reference <automodule>` for more information.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -49,7 +49,7 @@ If you are running Ubuntu or Debian Linux you can get all the DroneKit dependenc
 
 ::
 
-    sudo apt-get install pip python-numpy python-opencv python-serial python-pyparsing python-wxgtk2.8
+    sudo apt-get install python-pip python-numpy python-opencv python-serial python-pyparsing python-wxgtk2.8
 
 
 OSX dependencies

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,11 @@
 Welcome to DroneKit-Python's documentation!
 ===========================================
 
-DroneKit-Python provides interfaces for creating  applications that run on an onboard Linux computer communicating directly to the autopilot of 3DR-powered vehicles or applications that run on a personal computer communicating with vehicles over a wireless connection.
+DroneKit's Python API helps you create powerful apps for both ground and air-based control of UAVs.
 
-DroneKit is compatible with all vehicles using the `MAVLink protocol <http://qgroundcontrol.org/mavlink/start>`_. This includes most vehicles made by 3DR and other members of the `DroneCode foundation <https://www.dronecode.org/about/project-members>`_.
+The API makes it easy for your ground station apps to get information from UAVs and automate new kinds of flight behaviour. DroneKit-Python code running on a UAV's `Companion Computer <http://dev.ardupilot.com/wiki/companion-computers/>`_ can further augment the autopilot — performing tasks that are both computationally intensive and require a low-latency link (e.g. computer vision). 
+
+DroneKit is compatible with all vehicles using the `MAVLink protocol <http://qgroundcontrol.org/mavlink/start>`_ (including most vehicles made by 3DR and other members of the `DroneCode foundation <https://www.dronecode.org/about/project-members>`_). The APIs can be used in ground-based person computers running Windows, Linux or Mac OS X and with *Companion Computers* running Linux. 
 
 Contents:
 
@@ -22,3 +24,7 @@ Contents:
    example_3
    example_4
    automodule
+
+
+
+


### PR DESCRIPTION
Rename API Reference doc as discussed in #36
Improve the index.rst python docs entry point as discussed in #40 
Fixed pip dependency information (to python-pip) as discussed in #41 