### PR TITLE
bump sphinx theme version to a stable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ poster==0.8.1
 protobuf==2.6.1
 requests==2.5.1
 pymavlink>=1.1.39
-sphinx-3dr-theme>=0.0.1
+sphinx-3dr-theme>=0.0.6


### PR DESCRIPTION
previously the builds failed due to a package problem on the theme where
it didnt include required files for the theme.