### PR TITLE
Hide Vehicle.delete from api docs

### DIFF
--- a/docs/automodule.rst
+++ b/docs/automodule.rst
@@ -8,7 +8,7 @@ DroneKit-Python API Reference
 .. automodule:: droneapi.lib
    :members:
    :inherited-members:
-   :exclude-members: Mission, get_mission, ConnectionInfo, web_connect, AuthInfo
+   :exclude-members: Mission, get_mission, ConnectionInfo, web_connect, AuthInfo, delete
    
 
 

--- a/droneapi/lib/__init__.py
+++ b/droneapi/lib/__init__.py
@@ -557,12 +557,13 @@ class Vehicle(HasObservers):
         return self._parameters
 
     def delete(self):
-        """Delete this vehicle object.
+        """
+        Delete this vehicle object.
 
-        This requests deletion of the object on the server, this operation may throw an exception on failure (i.e. for
+        This requests deletion of the Vehicle object on the server. This operation may throw an exception on failure (i.e. for
         local connections or insufficient user permissions).
 		
-        .. todo:: Confirm whether this is public or not, and what it means in the context of a companion computer.
+        It is not supported for local connections.
         """
         pass
 


### PR DESCRIPTION
Hide Vehicle.delete from api docs, as discussed in #65. 

This also updates the documentation source, to ensure make the fact that the API is not for local connections obvious for people reading the source file.