### PR TITLE
Update all examples to include source code section

### DIFF
--- a/docs/examples/drone_delivery.rst
+++ b/docs/examples/drone_delivery.rst
@@ -79,3 +79,12 @@ We start running a web server by calling ``cherrypy.engine.start()``.
 *CherryPy* is a very small and simple webserver.  It is probably best to refer to their eight line `tutorial <http://www.cherrypy.org/>`_ for more information.
 
 Next we'll look at the basics of using the webservice and the local vehicle API to 'replay' a flight which has been uploaded to `Droneshare <http://droneshare.com>`_.
+
+
+Source code
+===========
+
+The full source code at documentation build-time is listed below (`current version on github <https://github.com/diydrones/dronekit-python/blob/master/example/drone_delivery/drone_delivery.py>`_):
+
+.. include:: ../../example/drone_delivery/drone_delivery.py
+    :literal:

--- a/docs/examples/flight_replay.rst
+++ b/docs/examples/flight_replay.rst
@@ -18,7 +18,7 @@ Now we'll launch **flight_replay.py** (/example/flight_replay/flight_replay.py) 
 
 One possible use of some variant of this tool to replay your old flights at your regular test field.
 
-:: 
+::
 
 	STABILIZE> api start flight_replay.py 101
 	STABILIZE> JSON downloaded...
@@ -87,3 +87,14 @@ We generate up to 100 waypoints for the vehicle with the following code:
         cmds.add(cmd)
     v.flush()
 
+
+Next we'll work with existing Linux services (gpsd) to add a new drone based feature called :ref:`Follow Me <example_follow_me>`.
+
+
+Source code
+===========
+
+The full source code at documentation build-time is listed below (`current version on github <https://github.com/diydrones/dronekit-python/blob/master/example/flight_replay/flight_replay.py>`_):
+
+.. include:: ../../example/flight_replay/flight_replay.py
+    :literal:

--- a/docs/examples/follow_me.rst
+++ b/docs/examples/follow_me.rst
@@ -1,4 +1,5 @@
 .. _example_follow_me:
+
 ======================
 Example: Follow Me
 ======================
@@ -37,3 +38,11 @@ The source code for this example is a good starting point for your own applicati
 
 Next, take a look at the full :ref:`api_reference` for more information.
 
+
+Source code
+===========
+
+The full source code at documentation build-time is listed below (`current version on github <https://github.com/diydrones/dronekit-python/blob/master/example/follow_me/follow_me.py>`_):
+
+.. include:: ../../example/follow_me/follow_me.py
+    :literal:

--- a/docs/examples/simple_goto.rst
+++ b/docs/examples/simple_goto.rst
@@ -37,3 +37,12 @@ It tells the vehicle to fly to a specified lat/long and hover at that location (
 
 
 Building on the basic vehicle control you just learned, we now show how to write a small web application that allows you to command a drone to fly to a particular location.
+
+
+Source code
+===========
+
+The full source code at documentation build-time is listed below (`current version on github <https://github.com/diydrones/dronekit-python/blob/master/example/simple_goto/simple_goto.py>`_):
+
+.. include:: ../../example/simple_goto/simple_goto.py
+    :literal:


### PR DESCRIPTION
same as #79 but rebased

from before:

```
The new "Source code" section imports and displays the current build-time source file for the example and also includes a link to the version of the file on github. This has been added to the four current examples.
```