### PR TITLE
Improve copter simple_goto and adds guide and reference for takeoff

### DIFF
--- a/docs/examples/simple_goto.rst
+++ b/docs/examples/simple_goto.rst
@@ -1,42 +1,133 @@
-========================
-Example: Simple Go To
-========================
+.. _example_simple_goto:
 
-This little demonstration just tells the vehicle to fly to a couple of different locations in the world.  You can edit the code to pick a latitude and longitude close to your position.
+==============================
+Example: Simple Go To (Copter)
+==============================
+
+This example demonstrates how to arm and launch a Copter in GUIDED mode, travel to a number of waypoints, and then return 
+to the home location. It uses :py:func:`Vehicle.commands.takeoff() <droneapi.lib.CommandSequence.takeoff>`, 
+:py:func:`Vehicle.commands.goto() <droneapi.lib.CommandSequence.goto>` and :py:attr:`Vehicle.mode <droneapi.lib.Vehicle.mode>`.
+
+The locations used are centred around the home location when the :ref:`Simulated Vehicle <vagrant-sitl-from-full-image>` is booted; you can edit the latitude and longitude 
+to use more appropriate positions for your own vehicle. 
+
+.. note:: 
+
+    This example will only run on *Copter*:
+
+    * *Plane* does not support ``takeoff`` in GUIDED mode. 
+    * *Rover* will ignore the ``takeoff`` command and will then stick at the altitude check.
+   
+
 
 Running the example
 ===================
 
-Once Mavproxy is running and the API is loaded, you can run this small example by typing: ``api start simple_goto.py``
+The vehicle and DroneKit should be set up as described in the :ref:`quick-start` or :ref:`get-started`.
 
-It will tell your vehicle to start flying to a particular latitude and longitude stored in the file (though for safety the take-off command is not included - you must manually tell vehicle to fly).  On the mavproxy console you should see:
+If you're using a simulated vehicle, remember to :ref:`disable arming checks <disable-arming-checks>` so 
+that the example can run.
 
-::
+Once MAVProxy is running and the API is loaded, you can start the example by typing: ``api start simple_goto.py``.
 
-	STABILIZE> api start simple_goto.py
-	STABILIZE> Got MAVLink msg: MISSION_ACK {target_system : 255, target_component : 0, type : 0}
-	GUIDED> Mode GUIDED
-	APIThread-0 exiting...
-	Got MAVLink msg: MISSION_ACK {target_system : 255, target_component : 0, type : 0}
+.. note:: 
+
+    The command above assumes you started the *MAVProxy* prompt in a directory containing the example script. If not, 
+    you will have to specify the full path to the script (something like):
+    ``api start /home/user/git/dronekit-python/example/simple_goto/simple_goto.py``.
+
+.. tip::	
+
+    It is more interesting to watch the example above on a map than the console. The topic :ref:`viewing_uav_on_map` 
+    explains how to set up *Mission Planner* to view a vehicle running on the simulator (SITL).
+
+On the *MAVProxy* console you should see (something like):
+
+.. code-block:: python
+
+    MAV> api start simple_goto.py
+    STABILIZE> Basic pre-arm checks
+    Arming motors
+     Waiting for arming...
+     Waiting for arming...
+    APM: ARMING MOTORS
+    APM: GROUND START
+     Waiting for arming...
+     Waiting for arming...
+    GUIDED> Mode GUIDED
+    APM: Initialising APM...
+    Got MAVLink msg: COMMAND_ACK {command : 400, result : 0}
+    Waiting for arming...
+    ARMED
+    Taking off!
+     Altitude:  0.0
+    Got MAVLink msg: COMMAND_ACK {command : 22, result : 0}
+     Altitude:  0.10000000149
+     Altitude:  0.620000004768
+     ...
+     Altitude:  19.25
+    Reached target altitude
+    Going to first point...
+    Got MAVLink msg: MISSION_ACK {target_system : 255, target_component : 0, type : 0}
+    Going to second point...
+    Got MAVLink msg: MISSION_ACK {target_system : 255, target_component : 0, type : 0}
+    Returning to Launch
+    APIThread-0 exiting...	
+	
+.. tip::	
+
+    If you get stuck in ``Waiting for arming...`` it is very likely that the vehicle did not pass all pre-arm checks. 
+    On a real device you can view the controller LEDs to determine likely issues. On the Simulator console you 
+    can disable the checks if needed:
+
+    .. code-block:: bash
+
+        STABILIZE>param load ../Tools/autotest/copter_params.parm
+        STABILIZE>param set ARMING_CHECK 0
 
 
 How does it work?
 =================
 
-The key code in this demo is the following:
+The code has three distinct sections: arming and takeoff, flight to a specified location, and return-to-home.
 
-::
+Takeoff
+-------
 
-	vehicle.mode    = VehicleMode("GUIDED")
-	origin          = Location(-34.364114, 149.166022, 30, is_relative=True)
+To launch *Copter* you need to set the mode to ``GUIDED``, arm the vehicle, and then call 
+:py:func:`Vehicle.commands.takeoff() <droneapi.lib.CommandSequence.takeoff>`. The takeoff code in this example
+is explained in the guide topic :ref:`taking-off`.
 
-	commands.goto(origin)
-	vehicle.flush()
+	
+Flying to a point - Goto
+------------------------
 
-It tells the vehicle to fly to a specified lat/long and hover at that location (30 meters in the air).  ``is_relative=True`` is the default and is recommended - it means that the altitude (30 meters) is *relative* to the vehicle home location.  If you had set ``is_relative`` to ``false``, it would have told the vehicle to fly to a specified mean-sea-level which is probably not what you want unless you are next to an ocean.
+The vehicle is already in ``GUIDED`` mode, so to send it to a certain point we just need to 
+call :py:func:`Vehicle.commands.goto() <droneapi.lib.CommandSequence.goto>` with the target location, 
+and then :py:func:`flush() <droneapi.lib.Vehicle.flush>` the command:
+
+.. code-block:: python	
+
+    point1 = Location(-35.361354, 149.165218, 20, is_relative=True)
+    vehicle.commands.goto(point1)
+    vehicle.flush()
+
+    # sleep so we can see the change in map
+    time.sleep(30)
+
+Without some sort of "wait" the next command would be executed immediately. In this example we just 
+sleep for 30 seconds - a good opportunity to observe the vehicle's movement on a map. 
 
 
-Building on the basic vehicle control you just learned, we now show how to write a small web application that allows you to command a drone to fly to a particular location.
+RTL - Return to launch
+------------------------
+
+To return to the home position and land, we set the mode to ``RTL``:
+
+.. code-block:: python	
+
+    vehicle.mode    = VehicleMode("RTL")
+    vehicle.flush()
 
 
 Source code
@@ -44,5 +135,5 @@ Source code
 
 The full source code at documentation build-time is listed below (`current version on github <https://github.com/diydrones/dronekit-python/blob/master/example/simple_goto/simple_goto.py>`_):
 
-.. include:: ../../example/simple_goto/simple_goto.py
-    :literal:
+.. literalinclude:: ../../example/simple_goto/simple_goto.py
+    :language: python

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -11,4 +11,5 @@ The guide contains how-to documentation for using the DroneKit-Python API. These
     getting_started
     companion-computers
     vehicle_state_and_parameters
+    taking_off
     debugging

--- a/docs/guide/taking_off.rst
+++ b/docs/guide/taking_off.rst
@@ -1,0 +1,125 @@
+.. _taking-off:
+
+==========
+Taking Off
+==========
+
+This article explains how to get your *Copter* to take off. At high level, the steps are: set the mode to ``GUIDED``, 
+arm the vehicle, and then call :py:func:`Vehicle.commands.takeoff() <droneapi.lib.CommandSequence.takeoff>`.  
+
+.. todo:: 
+
+    Plane apps take off using the ``MAV_CMD_NAV_TAKEOFF`` command in a mission. The plane should first arm and then change to
+    ``AUTO`` mode to start the mission. The action here is to add a link when we have an example we can point to.
+
+
+.. tip::
+
+    Copter is always started in ``GUIDED`` mode. Copter will not take off ``AUTO`` mode even if you have a 
+    `MAV_CMD_NAV_TAKEOFF <http://copter.ardupilot.com/common-mavlink-mission-command-messages-mav_cmd/#copter-2>`_ waypoint 
+    in your mission (you can run a mission by switching to ``AUTO`` mode after you're in the air).
+
+The code below shows a function to arm a Copter, take off, and fly to a specified altitude. This is taken from :ref:`example_simple_goto`.
+
+.. code-block:: python
+
+    api = local_connect()
+    vehicle = api.get_vehicles()[0]
+
+    def arm_and_takeoff(aTargetAltitude):
+        """
+        Arms vehicle and fly to aTargetAltitude.
+        """
+
+        print "Basic pre-arm checks"
+        # Don't let the user try to fly autopilot is booting
+        if vehicle.mode.name == "INITIALISING":
+            print "Waiting for vehicle to initialise"
+            time.sleep(1)
+        while vehicle.gps_0.fix_type < 2:
+            print "Waiting for GPS...:", vehicle.gps_0.fix_type
+            time.sleep(1)
+		
+        print "Arming motors"
+        # Copter should arm in GUIDED mode
+        vehicle.mode    = VehicleMode("GUIDED")
+        vehicle.armed   = True
+        vehicle.flush()
+
+        while not vehicle.armed and not api.exit:
+            print " Waiting for arming..."
+            time.sleep(1)
+
+        print "Taking off!"
+        vehicle.commands.takeoff(aTargetAltitude) # Take off to target altitude
+        vehicle.flush()
+
+        # Wait until the vehicle reaches a safe height before processing the goto (otherwise the command 
+        #  after Vehicle.commands.takeoff will execute immediately).
+        while not api.exit:
+            print " Altitude: ", vehicle.location.alt
+            if vehicle.location.alt>=aTargetAltitude*0.95: #Just below target, in case of undershoot.
+                print "Reached target altitude"
+                break;
+            time.sleep(1)
+
+    arm_and_takeoff(3)
+	
+
+The function first performs some pre-arm checks.
+
+.. note:: 
+
+    Arming turns on the vehicle's motors in preparation for flight. The flight controller will not arm
+    until the vehicle has passed a series of pre-arm checks to ensure that it is safe to fly.
+
+DroneKit-Python can't check every possible symptom that might prevent arming, but we can confirm that the 
+vehicle has booted and has a GPS lock:
+
+.. code-block:: python
+
+    if v.mode.name == "INITIALISING":
+        print "Waiting for vehicle to initialise"
+        time.sleep(1)
+    while vehicle.gps_0.fix_type < 2:
+        print "Waiting for GPS...:", vehicle.gps_0.fix_type
+        time.sleep(1)
+
+Once the vehicle is ready we set the mode to ``GUIDED`` and arm it. We then call :py:func:`flush() <droneapi.lib.Vehicle.flush>`
+to guarantee that the commands have been sent, and then wait until arming is confirmed before sending the 
+:py:func:`takeoff <droneapi.lib.CommandSequence.takeoff>` command.
+
+.. code-block:: python
+	
+    print "Arming motors"
+    # Copter should arm in GUIDED mode
+    vehicle.mode    = VehicleMode("GUIDED")
+    vehicle.armed   = True
+    vehicle.flush()
+
+    while not vehicle.armed and not api.exit:
+        print " Waiting for arming..."
+        time.sleep(1)
+
+    print "Taking off!"
+    vehicle.commands.takeoff(aTargetAltitude) # Take off to target altitude
+    vehicle.flush()
+
+The ``takeoff`` command is asynchronous and can be interrupted if another command arrives before it reaches 
+the target altitude. This could have potentially serious consequences if the vehicle is commanded to move 
+horizontally before it reaches a safe height. In addition, there is no message sent back from the vehicle 
+to inform the client code that the target altitude has been reached.
+
+To address these issues, the function waits until the vehicle reaches a specified height before returning. If you're not
+so concerned about reaching a particular height, a simpler implementation might just "wait" for a few seconds.
+	
+.. code-block:: python	
+
+    while not api.exit:
+        print " Altitude: ", vehicle.location.alt
+        if vehicle.location.alt>=aTargetAltitude*0.95: #Just below target, in case of undershoot.
+            print "Reached target altitude"
+            break;
+        time.sleep(1)
+
+When the function returns the app can continue in ``GUIDED`` mode or switch to ``AUTO`` mode to start a mission.

--- a/droneapi/lib/__init__.py
+++ b/droneapi/lib/__init__.py
@@ -823,10 +823,27 @@ class CommandSequence(object):
             lat, lon, altitude)
         cmds.add(cmd)
         vehicle.flush()	
+		
 
+    .. py:function:: takeoff(altitude)
+	
+        .. note:: This function should only be used on Copter vehicles.
 
+        Take off and fly the vehicle to the specified altitude (in metres) and then wait for another command. 
 
-    .. todo:: HW Add CommandSequence.takeoff - should be in public API: https://github.com/diydrones/dronekit-python/issues/64
+        The vehicle must be in ``GUIDED`` mode and armed before this is called.
+
+        There is no mechanism for notification when the correct altitude is reached, and if another command arrives
+        before that point (e.g. :py:func:`goto`) it will be run instead. 
+
+        .. warning:: 
+
+            Apps should code to ensure that the vehicle will reach a safe altitude before other commands are executed.
+            A good example is provided in the guide topic :ref:`taking-off`.
+
+        :param altitude: Target height, in metres.
+
+        .. todo:: This is a hack. The actual function should be defined here. See https://github.com/diydrones/dronekit-python/issues/64
     """
 
     def download(self):
@@ -844,6 +861,7 @@ class CommandSequence(object):
 		This can be called after :py:func:`download()` to block the thread until the asynchronous download is complete.
 		'''
         pass
+
 
     def goto(self, location):
         '''

--- a/example/simple_goto/simple_goto.py
+++ b/example/simple_goto/simple_goto.py
@@ -1,48 +1,75 @@
+"""
+simple_goto.py: GUIDED mode "simple goto" example (Copter Only)
+
+The example demonstrates how to arm and takeoff in Copter and how to navigate to 
+points using Vehicle.commands.goto.
+
+Full documentation is provided at http://python.dronekit.io/examples/simple_goto.html
+"""
+
 import time
 from droneapi.lib import VehicleMode, Location
 from pymavlink import mavutil
 
-api             = local_connect()
-vehicle         = api.get_vehicles()[0]
+api = local_connect()
+vehicle = api.get_vehicles()[0]
 
-def arm_and_takeoff():
-    """Dangerous: Arm and takeoff vehicle - use only in simulation"""
-    # NEVER DO THIS WITH A REAL VEHICLE - it is turning off all flight safety checks
-    # but fine for experimenting in the simulator.
-    print "Arming and taking off"
-    vehicle.mode    = VehicleMode("STABILIZE")
-    vehicle.parameters["ARMING_CHECK"] = 0
+def arm_and_takeoff(aTargetAltitude):
+    """
+    Arms vehicle and fly to aTargetAltitude.
+    """
+
+    print "Basic pre-arm checks"
+    # Don't let the user try to fly autopilot is booting
+    if vehicle.mode.name == "INITIALISING":
+        print "Waiting for vehicle to initialise"
+        time.sleep(1)
+    while vehicle.gps_0.fix_type < 2:
+        print "Waiting for GPS...:", vehicle.gps_0.fix_type
+        time.sleep(1)
+		
+    print "Arming motors"
+    # Copter should arm in GUIDED mode
+    vehicle.mode    = VehicleMode("GUIDED")
     vehicle.armed   = True
     vehicle.flush()
 
     while not vehicle.armed and not api.exit:
-        print "Waiting for arming..."
+        print " Waiting for arming..."
         time.sleep(1)
 
     print "Taking off!"
-    vehicle.commands.takeoff(20) # Take off to 20m height
-
-    # Pretend we have a RC transmitter connected
-    rc_channels = vehicle.channel_override
-    rc_channels[3] = 1500 # throttle
-    vehicle.channel_override = rc_channels
-
+    vehicle.commands.takeoff(aTargetAltitude) # Take off to target altitude
     vehicle.flush()
-    time.sleep(10)
 
-arm_and_takeoff()
+    # Wait until the vehicle reaches a safe height before processing the goto (otherwise the command 
+    #  after Vehicle.commands.takeoff will execute immediately).
+    while not api.exit:
+        print " Altitude: ", vehicle.location.alt
+        if vehicle.location.alt>=aTargetAltitude*0.95: #Just below target, in case of undershoot.
+            print "Reached target altitude"
+            break;
+        time.sleep(1)
+
+arm_and_takeoff(20)
+
 
 print "Going to first point..."
-vehicle.mode    = VehicleMode("GUIDED")
-origin          = Location(-34.364114, 149.266022, 20, is_relative=True)
+point1 = Location(-35.361354, 149.165218, 20, is_relative=True)
+vehicle.commands.goto(point1)
+vehicle.flush()
 
-vehicle.commands.goto(origin)
+# sleep so we can see the change in map
+time.sleep(30)
+
+print "Going to second point..."
+point2 = Location(-35.363244, 149.168801, 20, is_relative=True)
+vehicle.commands.goto(point2)
 vehicle.flush()
 
 # sleep so we can see the change in map
 time.sleep(20)
 
-print "Going to second point..."
-destination     = Location(-35.3652610, 149.1652300, 20, is_relative=True)
-vehicle.commands.goto(destination)
+print "Returning to Launch"
+vehicle.mode    = VehicleMode("RTL")
 vehicle.flush()


### PR DESCRIPTION
The previous simple_goto example had a number of problems, including using channel_override for thrust rather than the takeoff command, lack of pre-arm checks. The update does it the right way. I updated the example documentation along with this.

In addition, I created a guide topic for taking off (copter only) and added apireference for the takeoff function (note, this is just in "text" and I still think we need to expose the method in the API properly).