### PR TITLE
Improve Rangefinder attributed documentation

### DIFF
--- a/docs/examples/vehicle_state.rst
+++ b/docs/examples/vehicle_state.rst
@@ -15,8 +15,11 @@ Running the example
 ===================
 
 The vehicle and DroneKit should be set up as described in :ref:`get-started`.
-If you're using a simulated vehicle, remember to :ref:`disable arming checks <disable-arming-checks>` so 
-that the example can run.
+
+If you're using a simulated vehicle remember to :ref:`disable arming checks <disable-arming-checks>` so 
+that the example can run. You can also `add a virtual rangefinder <http://dev.ardupilot.com/wiki/simulation-2/sitl-simulator-software-in-the-loop/using-sitl-for-ardupilot-testing/#adding_a_virtual_rangefinder>`_
+(otherwise the :py:attr:`Vehicle.rangefinder <droneapi.lib.Vehicle.rangefinder>` attribute may return values of ``None`` for the distance
+and voltage). 
 
 Once MAVProxy is running and the API is loaded, you can start the example by typing: ``api start vehicle_state.py``.
 
@@ -42,6 +45,9 @@ On the *MAVProxy* console you should see (something like):
      Airspeed: 0.0
      Mount status: [None, None, None]
      Battery: Battery voltage: 12590, current: 0, level: 99
+     Rangefinder: Rangefinder: distance=0.189999997616, voltage=0.0190000012517
+     Rangefinder distance: 0.189999997616
+     Rangefinder voltage: 0.0190000012517
      Mode: STABILIZE
      Armed: False
     Set Vehicle.mode=GUIDED (currently: STABILIZE)
@@ -76,7 +82,7 @@ On the *MAVProxy* console you should see (something like):
      Channel default values: {'1': 1500, '3': 1000, '2': 1500, '5': 1800, '4': 1500, '7': 1000, '6': 1000, '8': 1800}
      Cancelling override
 
-    Reset vehicle atributes/parameters and exit
+    Reset vehicle attributes/parameters and exit
     Got MAVLink msg: COMMAND_ACK {command : 11, result : 0}
     APM: DISARMING MOTORS
     Got MAVLink msg: COMMAND_ACK {command : 400, result : 0}

--- a/droneapi/lib/__init__.py
+++ b/droneapi/lib/__init__.py
@@ -196,8 +196,8 @@ class Rangefinder(object):
     """
     Rangefinder readings.
 
-    :param distance: Distance.
-    :param voltage: Voltage.
+    :param distance: Distance (metres). ``None`` if the vehicle doesn't have a rangefinder.
+    :param voltage: Voltage (volts). ``None`` if the vehicle doesn't have a rangefinder.
     """
     def __init__(self, distance, voltage):
         self.distance = distance
@@ -479,6 +479,11 @@ class Vehicle(HasObservers):
     .. py:attribute:: battery
 
         Current system :py:class:`Battery` status.
+
+
+    .. py:attribute:: rangefinder
+
+        :py:class:`Rangefinder` distance and voltage values. 
 
 
     .. py:attribute:: channel_override

--- a/examples/vehicle_state/vehicle_state.py
+++ b/examples/vehicle_state/vehicle_state.py
@@ -1,12 +1,11 @@
-#
-# This example shows how to use DroneKit-Python to get and set vehicle state, parameter and channel-override information. 
-# It also demonstrates how to observe vehicle attribute (state) changes. 
-# 
-# Usage:
-# * mavproxy.py
-# * module load api
-# * api start vehicle-state.py
-#
+"""
+vehicle_state.py: Get and set vehicle state, parameter and channel-override information. 
+
+It also demonstrates how to observe vehicle attribute (state) changes. 
+
+Full documentation is provided at http://python.dronekit.io/examples/vehicle_state.html
+"""
+
 from droneapi.lib import VehicleMode
 from pymavlink import mavutil
 import time
@@ -14,91 +13,93 @@ import time
 # First get an instance of the API endpoint
 api = local_connect()
 # Get the connected vehicle (currently only one vehicle can be returned).
-v = api.get_vehicles()[0]
+vehicle = api.get_vehicles()[0]
 
 # Get all vehicle attributes (state)
 print "\nGet all vehicle attribute values:"
-print " Location: %s" % v.location
-print " Attitude: %s" % v.attitude
-print " Velocity: %s" % v.velocity
-print " GPS: %s" % v.gps_0
-print " Groundspeed: %s" % v.groundspeed
-print " Airspeed: %s" % v.airspeed
-print " Mount status: %s" % v.mount_status
-print " Battery: %s" % v.battery
-print " Mode: %s" % v.mode.name    # settable
-print " Armed: %s" % v.armed    # settable
+print " Location: %s" % vehicle.location
+print " Attitude: %s" % vehicle.attitude
+print " Velocity: %s" % vehicle.velocity
+print " GPS: %s" % vehicle.gps_0
+print " Groundspeed: %s" % vehicle.groundspeed
+print " Airspeed: %s" % vehicle.airspeed
+print " Mount status: %s" % vehicle.mount_status
+print " Battery: %s" % vehicle.battery
+print " Rangefinder: %s" % vehicle.rangefinder
+print " Rangefinder distance: %s" % vehicle.rangefinder.distance
+print " Rangefinder voltage: %s" % vehicle.rangefinder.voltage
+print " Mode: %s" % vehicle.mode.name    # settable
+print " Armed: %s" % vehicle.armed    # settable
 
 
 # Set vehicle mode and armed attributes (the only settable attributes)
-print "Set Vehicle.mode=GUIDED (currently: %s)" % v.mode.name 
-v.mode = VehicleMode("GUIDED")
-v.flush()  # Flush to guarantee that previous writes to the vehicle have taken place
-while not v.mode.name=='GUIDED' and not api.exit:  #Wait until mode has changed
+print "Set Vehicle.mode=GUIDED (currently: %s)" % vehicle.mode.name 
+vehicle.mode = VehicleMode("GUIDED")
+vehicle.flush()  # Flush to guarantee that previous writes to the vehicle have taken place
+while not vehicle.mode.name=='GUIDED' and not api.exit:  #Wait until mode has changed
     print " Waiting for mode change ..."
     time.sleep(1)
 
-print "Set Vehicle.armed=True (currently: %s)" % v.armed 
-v.armed = True
-v.flush()
-while not v.armed and not api.exit:
+print "Set Vehicle.armed=True (currently: %s)" % vehicle.armed 
+vehicle.armed = True
+vehicle.flush()
+while not vehicle.armed and not api.exit:
     print " Waiting for arming..."
     time.sleep(1)
 
 
 # Show how to add and remove and attribute observer callbacks (using mode as example) 
 def mode_callback(attribute):
-    print " CALLBACK: Mode changed to: ", v.mode.name
+    print " CALLBACK: Mode changed to: ", vehicle.mode.name
 
 print "\nAdd mode attribute observer for Vehicle.mode" 
-v.add_attribute_observer('mode', mode_callback)	
+vehicle.add_attribute_observer('mode', mode_callback)	
 
-print " Set mode=STABILIZE (currently: %s)" % v.mode.name 
-v.mode = VehicleMode("STABILIZE")
-v.flush()
+print " Set mode=STABILIZE (currently: %s)" % vehicle.mode.name 
+vehicle.mode = VehicleMode("STABILIZE")
+vehicle.flush()
 
 print " Wait 2s so callback invoked before observer removed"
 time.sleep(2)
 
 # Remove observer - specifying the attribute and previously registered callback function
-v.remove_attribute_observer('mode', mode_callback)	
+vehicle.remove_attribute_observer('mode', mode_callback)	
 
 
 #  Get Vehicle Home location ((0 index in Vehicle.commands)
 print "\nGet home location" 
-cmds = v.commands
+cmds = vehicle.commands
 cmds.download()
 cmds.wait_valid()
 print " Home WP: %s" % cmds[0]
 
 
 #  Get/Set Vehicle Parameters
-print "\nRead vehicle param 'THR_MIN': %s" % v.parameters['THR_MIN']
+print "\nRead vehicle param 'THR_MIN': %s" % vehicle.parameters['THR_MIN']
 print "Write vehicle param 'THR_MIN' : 10"
-v.parameters['THR_MIN']=10
-v.flush()
-print "Read new value of param 'THR_MIN': %s" % v.parameters['THR_MIN']
+vehicle.parameters['THR_MIN']=10
+vehicle.flush()
+print "Read new value of param 'THR_MIN': %s" % vehicle.parameters['THR_MIN']
 
 
 # Overriding an RC channel
 # NOTE: CHANNEL OVERRIDES may be useful for simulating user input and when implementing certain types of joystick control. 
 #DO NOT use unless there is no other choice (there almost always is!)
 print "\nOverriding RC channels for roll and yaw"
-v.channel_override = { "1" : 900, "4" : 1000 }
-v.flush()
-print " Current overrides are:", v.channel_override
-print " Channel default values:", v.channel_readback  # All channel values before override
+vehicle.channel_override = { "1" : 900, "4" : 1000 }
+vehicle.flush()
+print " Current overrides are:", vehicle.channel_override
+print " Channel default values:", vehicle.channel_readback  # All channel values before override
 
 # Cancel override by setting channels to 0
 print " Cancelling override"
-v.channel_override = { "1" : 0, "4" : 0 }
-v.flush()
+vehicle.channel_override = { "1" : 0, "4" : 0 }
+vehicle.flush()
 
 
 ## Reset variables to sensible values.
-print "\nReset vehicle atributes/parameters and exit"
-v.mode = VehicleMode("STABILIZE")
-v.armed = False
-v.parameters['THR_MIN']=130
-v.flush()
-
+print "\nReset vehicle attributes/parameters and exit"
+vehicle.mode = VehicleMode("STABILIZE")
+vehicle.armed = False
+vehicle.parameters['THR_MIN']=130
+vehicle.flush()


### PR DESCRIPTION
1. Added vehicle.rangefinder attributed (only the class was documented). Updated class with units information and information about what happens if rangefinder not supported (returns None).

2. Updated the vehicle_state example and example docs to report the rangefinder values. The example docs now link to information on setting up simulated rangefinder. I took the option to change the Vehicle variable name from "v" to "vehicle" (purely for consistency with other examples) and tidy up the introductory text.

3. Updated the vehicle state guide to list the new attributes and show how they are obtained. I updated the section on using the observer to show how you can cache the value from the callback. I also made this behaviour sound less like a bug (#60).