### PR TITLE
Add python-dev as a dronekit dependency on linux

### DIFF
--- a/docs/guide/getting_started.rst
+++ b/docs/guide/getting_started.rst
@@ -39,7 +39,7 @@ If you are using Ubuntu or Debian Linux you can get most of the *DroneKit* depen
 
 .. code:: bash
 
-    sudo apt-get install python-pip python-numpy python-opencv python-serial python-pyparsing python-wxgtk2.8
+    sudo apt-get install python-pip python-dev python-numpy python-opencv python-serial python-pyparsing python-wxgtk2.8
 
 	
 The remaining dependencies (including `MAVProxy <http://tridge.github.io/MAVProxy/>`_), are 


### PR DESCRIPTION
Missing dependency. Thought I'd already added it but can't find a matching pull request.